### PR TITLE
fix(deps): resolve orjson dependency issues in gateway and auth_service

### DIFF
--- a/gateway/app/common/utility/logger.py
+++ b/gateway/app/common/utility/logger.py
@@ -1,5 +1,5 @@
 import logging
-import orjson
+import json
 from typing import Any, Dict, Optional
 from fastapi import Request, Response
 import time
@@ -54,7 +54,7 @@ class GatewayLogger:
         body_data = None
         if body:
             try:
-                body_data = orjson.loads(body)
+                body_data = json.loads(body)
                 body_data = SensitiveDataFilter.mask_sensitive_data(body_data)
             except:
                 body_data = "***BINARY_OR_INVALID_JSON***"
@@ -68,7 +68,7 @@ class GatewayLogger:
             "user_agent": request.headers.get("user-agent")
         }
         
-        self.logger.info(f"REQUEST: {orjson.dumps(log_data).decode()}")
+        self.logger.info(f"REQUEST: {json.dumps(log_data, ensure_ascii=False)}")
     
     def log_response(self, method: str, path: str, status_code: int, response_time: float):
         """응답 로깅"""
@@ -79,7 +79,7 @@ class GatewayLogger:
             "response_time_ms": round(response_time * 1000, 2)
         }
         
-        self.logger.info(f"RESPONSE: {orjson.dumps(log_data).decode()}")
+        self.logger.info(f"RESPONSE: {json.dumps(log_data, ensure_ascii=False)}")
     
     def log_error(self, message: str, error: Optional[Exception] = None):
         """에러 로깅"""

--- a/service/auth_service/requirements.txt
+++ b/service/auth_service/requirements.txt
@@ -8,7 +8,6 @@ passlib[bcrypt]==1.7.4
 python-jose[cryptography]==3.3.0
 PyJWT==2.8.0
 cryptography==41.0.7
-orjson==3.10.7
 psycopg2-binary==2.9.9
 email-validator==2.1.0
 pandas==2.2.1


### PR DESCRIPTION
- Replace orjson with standard json module in gateway logger.py
- Remove unused orjson dependency from auth_service requirements.txt
- Fix ModuleNotFoundError: No module named 'orjson' deployment issue
- Ensure all services can start without missing dependencies
- Gateway import test successful
- Maintain logging functionality with standard Python libraries